### PR TITLE
Staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,43 +8,38 @@ A live instance is running on github.io: see http://transformap.co/transformap-e
 
 You can do the following things:
 
-* Edit an existing place: call it with the ?place=UUID parameter, see example: http://transformap.co/transformap-editor/?place=e98fb9126657fd09e8c7e43217000e20
+* Edit an existing place: call it with the `?place=UUID` parameter, see example:
+http://transformap.co/transformap-editor/?place=e98fb9126657fd09e8c7e43217000e20
 * Add a new place: leave the UUID out, it will generate one on upload.
 
 To move the coordinates on the map, click “Edit Layers” in the bottom left corner, and drag the pin.
 
 To initially set coordinates, click “Draw a marker” in the bottom left corner.
 
-### SUSY Fork
-
-A fork tailored for the SUSY project has its repository [here](https://github.com/susy-partners/transformap-editor).
-
-Its live instance is here: https://susy-partners.github.io/transformap-editor/
-
 ## Installation
 
-* clone this repository.
-* npm install
+    git clone https://github.com/transformap/transformap-editor.git
+    npm install
 
 ## Development
 
-start the watching daemon: ```brunch watch --server -n```
+Start a watching daemon with `npm run watch`
 
 ### Isolation mode
 
 The development server instance can be started in an "isolated mode" where certain AJAX calls (See /app/test/intercept_ajax.js) are mocked for testing purposes.
 
-In order to start the daemon in isolation mode specify the "local" environment: ```brunch watch --server --env local```
+In order to start the daemon in isolation mode specify the `local` environment: `brunch watch --server --env local`
 
 ### Lint
 
-please run the linter after developing a feature:
+Please run the linter after developing a feature:
 
-```npm run lint```
+`npm run lint`
 
-if you want to automatically fix the most common things:
+If you want to automatically fix the most common things:
 
-```npm install standard --global```
+`npm install standard --global`
 
 and run it:
 
@@ -52,7 +47,9 @@ and run it:
     standard --fix
 
 
-# deployment to gh-pages
+# Deployment
+
+## Production environment
 
 * save the contents of the 'public' - folder
 * git checkout gh-pages
@@ -61,8 +58,18 @@ and run it:
 * git add
 * git push
 
+## Development environment
+
+If you are integrating feature branches into `staging`, run:
+
+    npm run deploy
+
+If you intend to push another branch, feel free to invoke the deploy script manually as follows:
+
+    ./scripts/deploy $upstream $branch $repo
+
 ### Unit & Integration tests
 
 A series of test files can be found under /test as well as some fixtures used for testing purposes.
 
-Run ```npm test```
+Run `npm test`

--- a/app/assets/.env
+++ b/app/assets/.env
@@ -1,0 +1,1 @@
+BUILDPACK_URL=https://github.com/florianheinemann/buildpack-nginx.git

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "standard app/**/*js",
     "start": "brunch watch --server",
     "build": "brunch build --production",
+    "deploy": "./scripts/deploy",
     "test": "mocha app/test",
     "postinstall": "./scripts/postinstall"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "standard app/**/*js",
     "start": "brunch watch --server",
-    "prod": "brunch build --production",
+    "build": "brunch build --production",
     "test": "mocha app/test",
     "postinstall": "./scripts/postinstall"
   },

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,28 +1,29 @@
 #!/usr/bin/env bash
+
 set -e -x
 git --version
+
 upstream=$1
 branch=$2
 REPO=$3
 : ${upstream:=origin}
-: ${branch:=master}
+: ${branch:=staging}
 : ${REPO:=git@github.com:transformap/transformap-editor.git}
 git fetch $upstream
 if [ `git rev-list HEAD...$upstream/$branch --count` -ne 0 ]; then
   echo "not deploying"
   exit 1
 fi
-npm i
-rm -rf public
 
+rm -rf public
 # use --reference when not in shallow clone
 # git clone $REPO --reference . -b dokku _public
-
 git clone $REPO -b dokku public
+
 rm -rf public/*
-source ./postinstall
+npm i
 REV=`git describe --always`
-BUILD=git-$REV brunch ./node_modules/brunch/bin/build --production build
+BUILD=git-$REV npm run build
 cd public
 git remote add deploy dokku@apps.allmende.io:transformap-editor
 git add -A .

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -11,7 +11,7 @@ REPO=$3
 : ${REPO:=git@github.com:transformap/transformap-editor.git}
 git fetch $upstream
 if [ `git rev-list HEAD...$upstream/$branch --count` -ne 0 ]; then
-  echo "not deploying"
+  printf "# Not deploying.\n# Please update your upstream branch with your local commits before proceeding.\n"
   exit 1
 fi
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e -x
+git --version
+upstream=$1
+branch=$2
+REPO=$3
+: ${upstream:=origin}
+: ${branch:=master}
+: ${REPO:=git@github.com:transformap/transformap-editor.git}
+git fetch $upstream
+if [ `git rev-list HEAD...$upstream/$branch --count` -ne 0 ]; then
+  echo "not deploying"
+  exit 1
+fi
+npm i
+rm -rf public
+
+# use --reference when not in shallow clone
+# git clone $REPO --reference . -b dokku _public
+
+git clone $REPO -b dokku public
+rm -rf public/*
+source ./postinstall
+REV=`git describe --always`
+BUILD=git-$REV brunch ./node_modules/brunch/bin/build --production build
+cd public
+git remote add deploy dokku@apps.allmende.io:transformap-editor
+git add -A .
+echo "regen for $REV" | git commit-tree `git write-tree` -p `git rev-parse HEAD` -p $REV | xargs git reset --hard
+git push origin dokku
+git push -f deploy dokku:master
+cd ..

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
 mkdir -p public
+
 cp -r node_modules/leaflet/dist/images/ public/
 cp -r node_modules/leaflet-draw/dist/images/ public/
+
+cp app/assets/.env public/
+cp app/assets/.static public/


### PR DESCRIPTION
This pull request comes with commits to build a staging environment at http://transformap-editor.apps.allmende.io/

It features:

* little documentation about how to use the build script, i.e. by invoking `./scripts/deploy acorbi impl-mocking-libs`
* Dokku related files and associated build logic
* a [deploy script](https://github.com/transforlab/hack.transforlab.net/blob/master/deploy) from hell (a.k.a. @g0v) that does weird things with [the `dokku` branch](https://github.com/TransforMap/transformap-editor/tree/dokku) (see commit log!), but makes sure build artefacts are never overwritten live before everything has been checked into version control, creates a clean build and backs it up to git, before pushing into the staging environment.